### PR TITLE
Height align all toolbar buttons

### DIFF
--- a/app/components/ToolbarButton/styles.css
+++ b/app/components/ToolbarButton/styles.css
@@ -2,7 +2,6 @@
   background: transparent;
   border: 0;
   float: left;
-  height: 100%;
   padding: 0;
   cursor: pointer;
   text-align: center;


### PR DESCRIPTION
Affects `Configure Packages`, `Info` and `Add File` buttons in `Toolbar`.

Before
![screen shot 2016-02-26 at 7 55 03 pm](https://cloud.githubusercontent.com/assets/6177621/13354753/faa5aef2-dcc2-11e5-818c-06f6015415d4.png)

After
![screen shot 2016-02-26 at 7 54 53 pm](https://cloud.githubusercontent.com/assets/6177621/13354749/f78e0e8a-dcc2-11e5-886c-e8808ef910a1.png)
