### PR TITLE
Increase width of input for adding new files

### DIFF
--- a/app/components/AddFile/styles.css
+++ b/app/components/AddFile/styles.css
@@ -25,7 +25,7 @@
   border-radius: 3px;
   margin-top: 9px;
   padding: 3px 10px;
-  width: 70px;
+  width: 200px;
   transition: width 0.25 ease-out;
   background-color: #eee;
   border: 0;


### PR DESCRIPTION
Since the input itself appears only after on click to the Add File button, I see no reason to give it enough room to breathe. Usually file names are huge like `Header` or `ToolbarButton`.

Before
![screen shot 2016-02-26 at 11 23 24 pm](https://cloud.githubusercontent.com/assets/6177621/13360686/5a4a4a4e-dce0-11e5-91a1-08537677e75b.png)

After
![screen shot 2016-02-26 at 11 23 32 pm](https://cloud.githubusercontent.com/assets/6177621/13360690/5f28d77e-dce0-11e5-84a2-f68e081d9f6a.png)
